### PR TITLE
Quadratic bezier curve may crash

### DIFF
--- a/XpsToPdf/PdfSharp.Xps.Rendering/WpfUtils.cs
+++ b/XpsToPdf/PdfSharp.Xps.Rendering/WpfUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Media;
 
@@ -30,10 +31,21 @@ namespace PdfSharp.Xps.Rendering
       }
       geo = geo.GetFlattenedPathGeometry();
       fig = geo.Figures[0];
-      PolyLineSegment lineSeg = (PolyLineSegment)fig.Segments[0];
+
       PdfSharp.Xps.XpsModel.PolyLineSegment resultSeg = new PdfSharp.Xps.XpsModel.PolyLineSegment();
-      foreach (Point point in lineSeg.Points)
-        resultSeg.Points.Add(new PdfSharp.Xps.XpsModel.Point(point.X, point.Y));
+      if (fig.Segments[0] is LineSegment lineSeg)
+      {
+        resultSeg.Points.Add(new PdfSharp.Xps.XpsModel.Point(lineSeg.Point.X, lineSeg.Point.Y));
+      }
+      else if (fig.Segments[0] is PolyLineSegment polyLineSeg)
+      {
+        foreach (Point point in polyLineSeg.Points)
+          resultSeg.Points.Add(new PdfSharp.Xps.XpsModel.Point(point.X, point.Y));
+      }
+      else
+      {
+        throw new NotImplementedException();
+      }
       return resultSeg;
     }
 


### PR DESCRIPTION
When creating XPS from XAML where a `PathGeometry` contains a line-prefixed quadratic bezier curve, the library crashes.

Note the `L` which implies a `LineSegment` instead of a `PolyLineSegment`. Thus, we need to handle these two types when flattening the curve.
```
M 2.779 0.937 L 0.85 2.92 Q 0.774 3.046 0.705 3.176 Z
```

This fixes issue #11.