### PR TITLE
Bugfix for rendering bulleted lists in certain cases

### DIFF
--- a/XpsToPdf/PdfSharp.Xps.Rendering/PdfContentWriter-Glyphs.cs
+++ b/XpsToPdf/PdfSharp.Xps.Rendering/PdfContentWriter-Glyphs.cs
@@ -122,14 +122,7 @@ namespace PdfSharp.Xps.Rendering
         for (int idx = 0; idx < length; idx++)
         {
           char ch = s[idx];
-          int glyphID = 0;
-          if (descriptor.fontData.cmap.symbol)
-          {
-            glyphID = (int)ch + (descriptor.fontData.os2.usFirstCharIndex & 0xFF00);
-            glyphID = descriptor.CharCodeToGlyphIndex((char)glyphID);
-          }
-          else
-            glyphID = descriptor.CharCodeToGlyphIndex(ch);
+          int glyphID = GetGlyphIndex(descriptor, ch);
           s2 += (char)glyphID;
         }
       }
@@ -467,7 +460,7 @@ namespace PdfSharp.Xps.Rendering
           if (mapping.HasGlyphIndex)
             glyphIndex = mapping.GlyphIndex;
           else
-            glyphIndex = descriptor.CharCodeToGlyphIndex(unicodeString[codeIdx]);
+            glyphIndex = GetGlyphIndex(descriptor,unicodeString[codeIdx]);
 
           // add glyph index to the fonts 'used glyph table'
           realizedFont.AddGlyphIndices(new string((char)glyphIndex, 1));
@@ -523,6 +516,26 @@ namespace PdfSharp.Xps.Rendering
           stop = true;
       }
       while (!stop);
+    }
+
+    /// <summary>
+    /// Helper method to retrieve the glpyh index from a font cmap for a given character
+    /// </summary>
+    /// <param name="descriptor"></param>
+    /// <param name="ch"></param>
+    /// <returns></returns>
+    private int GetGlyphIndex(OpenTypeDescriptor descriptor, char ch)
+    {
+            int glyphID = 0;
+            if (descriptor.fontData.cmap.symbol)
+            {
+                glyphID = (int)ch + (descriptor.fontData.os2.usFirstCharIndex & 0xFF00);
+                glyphID = descriptor.CharCodeToGlyphIndex((char)glyphID);
+            }
+            else
+                glyphID = descriptor.CharCodeToGlyphIndex(ch);
+            
+            return glyphID;
     }
   }
 }


### PR DESCRIPTION
When converting a sample XPS file generated from XAML with a bulleted list, the resulting PDF renders the bullet as an empty square glpyh instead. Attached is a sample test project which generates a minimal XPS file, along with the output and comparison document. 
[XpsToPdfTest.zip](https://github.com/user-attachments/files/16505075/XpsToPdfTest.zip)
[test_files.zip](https://github.com/user-attachments/files/16505080/test_files.zip)

This PR should fix the issue, it looks like the code to get the glyph index in the WriteGlyphs_ClusterMapping was not accounting for symbol fonts in the same way that the WriteGlyphs function was handling it. This refactors that code into a helper method so that it can be called from both functions.